### PR TITLE
Fix tests to run with HashRouter, add formatting

### DIFF
--- a/cypress/e2e/homepage_spec.cy.js
+++ b/cypress/e2e/homepage_spec.cy.js
@@ -1,19 +1,22 @@
 describe('Main Page', () => {
+    
     beforeEach(() => {
-    cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS',{fixture: "lists.json"})
-    cy.visit('http://localhost:3000')
-})
+        cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS', { fixture: 'lists.json' })
+        .visit('http://localhost:3000/#/');
+    });
+
     it('Should show the main page with a header', () => {
-        cy.get('.page-title').contains('Book Saver')
-        })
+        cy.get('.page-title').contains('Book Saver');
+    });
+
     it('User should be able to view different lists', () => {
         cy.get('.book-card').should('contain', 'IT STARTS WITH US')
-        cy.get('[name="Test List 2"]').click()
-        cy.get('.book-card').should('contain', 'OUTLIVE')
+        .get('[name="Test List 2"]').click()
+        .get('.book-card').should('contain', 'OUTLIVE');
+    });
 
-    })
     it('should take you to a new page with book details when you click on a book', () => {
-        cy.get('.book-card').click()
-    })
-})
+        cy.get('.book-card').click();
+    });
+});
     

--- a/cypress/e2e/login_spec.cy.js
+++ b/cypress/e2e/login_spec.cy.js
@@ -1,29 +1,33 @@
 describe('Login Page', () => {
-    beforeEach(() => {
-    cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS',{fixture: "lists.json"})
-    cy.visit('http://localhost:3000/login')
-})
-   it('Should be able to login', () => {
-       cy.get('#email').type('test@test.com')
-       cy.get('#pass').type('password')
-       cy.get('.submit').click()
-       cy.get('.users-name').should('contain', 'Hello, test testing!')
-    })
-    it('Should throw an error when we put in the wrong email', () => {
-        cy.get('#email').type('test')
-        cy.get('#pass').type('password')
-        cy.get('.submit').click()
-        cy.get('.error-code').should('contain', 'Invalid Username or Password')
-     })
-     it('Should throw an error when we put in the wrong password', () => {
-        cy.get('#email').type('test@test.com')
-        cy.get('#pass').type('pass')
-        cy.get('.submit').click()
-        cy.get('.error-code').should('contain', 'Invalid Username or Password')
-     })
-     it('Should throw an error when we dont enter user or password', () => {
-        cy.get('.submit').click()
-        cy.get('.error-code').should('contain', 'Invalid Username or Password')
-     })
    
-})
+   beforeEach(() => {
+      cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS', { fixture: 'lists.json' })
+      .visit('http://localhost:3000/#/login');
+   });
+
+   it('Should be able to login', () => {
+      cy.get('#email').type('test@test.com')
+      .get('#pass').type('password')
+      .get('.submit').click()
+      .get('.users-name').should('contain', 'Hello, test testing!');
+   });
+
+   it('Should throw an error when we put in the wrong email', () => {
+      cy.get('#email').type('test')
+      .get('#pass').type('password')
+      .get('.submit').click()
+      .get('.error-code').should('contain', 'Invalid Username or Password');
+   });
+
+   it('Should throw an error when we put in the wrong password', () => {
+      cy.get('#email').type('test@test.com')
+      .get('#pass').type('pass')
+      .get('.submit').click()
+      .get('.error-code').should('contain', 'Invalid Username or Password');
+   });
+
+   it('Should throw an error when we dont enter user or password', () => {
+      cy.get('.submit').click()
+      .get('.error-code').should('contain', 'Invalid Username or Password');
+   });
+});

--- a/cypress/e2e/register_spec.cy.js
+++ b/cypress/e2e/register_spec.cy.js
@@ -1,26 +1,30 @@
 describe('Register Page', () => {
-    beforeEach(() => {
-    cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS',{fixture: "lists.json"})
-    cy.visit('http://localhost:3000/register')
-})
-it('Should a 6 character password', () => {
-    cy.get('#first-name').type('testing')
-    cy.get('#email').type('test@testing.com')
-    cy.get('#pass').type('pass')
-    cy.get('.submit').click()
-    cy.get('.error-code').should('contain', 'Password must be at least 6 characters')
- })
- it('Should require a valid email', () => {
-    cy.get('#first-name').type('testing')
-    cy.get('#email').type('test')
-    cy.get('#pass').type('password')
-    cy.get('.submit').click()
-    cy.get('.error-code').should('contain', 'Invalid Email')
- })
- it('Should require a first name', () => {
-    cy.get('#email').type('test@test.com')
-    cy.get('#pass').type('password')
-    cy.get('.submit').click()
-    cy.get('.error-code').should('contain', 'Please enter a first name')
- })
-})
+   
+   beforeEach(() => {
+      cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS',{fixture: "lists.json"})
+      .visit('http://localhost:3000/#/register');
+   });
+   
+   it('Should require a 6 character password', () => {
+      cy.get('#first-name').type('testing')
+      .get('#email').type('test@testing.com')
+      .get('#pass').type('pass')
+      .get('.submit').click()
+      .get('.error-code').should('contain', 'Password must be at least 6 characters');
+   });
+
+   it('Should require a valid email', () => {
+      cy.get('#first-name').type('testing')
+      .get('#email').type('test')
+      .get('#pass').type('password')
+      .get('.submit').click()
+      .get('.error-code').should('contain', 'Invalid Email');
+   });
+
+   it('Should require a first name', () => {
+      cy.get('#email').type('test@test.com')
+      .get('#pass').type('password')
+      .get('.submit').click()
+      .get('.error-code').should('contain', 'Please enter a first name');
+   });
+});

--- a/cypress/e2e/singlepage_spec.cy.js
+++ b/cypress/e2e/singlepage_spec.cy.js
@@ -1,11 +1,13 @@
 describe('Main Page', () => {
-    beforeEach(() => {
+
+  beforeEach(() => {
     cy.intercept('GET', 'https://api.nytimes.com/svc/books/v3/lists/full-overview.json?api-key=JL2wo9KGenD4ya0vsuAP1IGxduivvAwS',{fixture: "lists.json"})
-    cy.visit('http://localhost:3000/book/9781668001226')
-})
-it('User should be able to view book details', () => {
+    .visit('http://localhost:3000/#/book/9781668001226');
+  });
+
+  it('User should be able to view book details', () => {
     cy.get('.sbook-title').should('contain', 'IT STARTS WITH US')
-    cy.get('.sbook-ranking').should('contain', 'Currently #1')
-    cy.get('.sbook-desc').should('contain', 'Lily deals with her jealous ex-husband')
-})
-})
+    .get('.sbook-ranking').should('contain', 'Currently #1')
+    .get('.sbook-desc').should('contain', 'Lily deals with her jealous ex-husband');
+  });
+});

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,5 +1,0 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}


### PR DESCRIPTION
Tests were visiting urls with no HashRouter, since it was implemented last for pages deployment. Also fixed up the formatting for developer empathy